### PR TITLE
fix: reset snap-comment after sending success and add color with tags

### DIFF
--- a/src/containers/DispatchPage/SnapCommentBar/constants.js
+++ b/src/containers/DispatchPage/SnapCommentBar/constants.js
@@ -2,17 +2,21 @@ export const cannedMessages = [
   {
     key: 1,
     content: 'Good!',
+    color: 'green',
   },
   {
     key: 2,
     content: 'Did not get it.',
+    color: 'blue',
   },
   {
     key: 3,
     content: 'Not so good!',
+    color: 'red',
   },
   {
     key: 4,
     content: 'Give a hint!',
+    color: 'blue',
   },
 ];

--- a/src/containers/DispatchPage/SnapCommentBar/index.js
+++ b/src/containers/DispatchPage/SnapCommentBar/index.js
@@ -16,6 +16,7 @@ import { createSnapComment } from 'redux/snapComment/actions';
 import { cannedMessages } from './constants';
 import styles from './SnapCommentBar.module.scss';
 
+export const FORM_ID = 'SnapCommentBar';
 class SnapCommentBar extends PureComponent {
   handleClickTag = content => () => {
     if (content) this.props.onChangeSnapComment(content);
@@ -36,6 +37,15 @@ class SnapCommentBar extends PureComponent {
     </Menu>
   );
 
+  renderTags = () => {
+    const messages = cannedMessages.slice(0, 3);
+    return messages.map(message => (
+      <Tag color={message.color} onClick={this.handleClickTag(message.content)}>
+        {message.content}
+      </Tag>
+    ));
+  };
+
   render() {
     const {
       handleSubmit,
@@ -49,17 +59,7 @@ class SnapCommentBar extends PureComponent {
           <Button className={styles.dropdownBtn}>Canned Messages</Button>
         </Dropdown>
         <div className={styles.rightSide}>
-          <div className={styles.tags}>
-            <Tag onClick={this.handleClickTag(cannedMessages[0].content)}>
-              {cannedMessages[0].content}
-            </Tag>
-            <Tag onClick={this.handleClickTag(cannedMessages[1].content)}>
-              {cannedMessages[1].content}
-            </Tag>
-            <Tag onClick={this.handleClickTag(cannedMessages[2].content)}>
-              {cannedMessages[2].content}
-            </Tag>
-          </div>
+          <div className={styles.tags}>{this.renderTags()}</div>
           <form
             className={styles.form}
             onSubmit={handleSubmit(onCreateSnapComment)}
@@ -91,7 +91,7 @@ SnapCommentBar.propTypes = {
 function mapDispatchToProps(dispatch) {
   return {
     onChangeSnapComment: content =>
-      dispatch(actions.change('SnapCommentBar', 'content', content)),
+      dispatch(actions.change(FORM_ID, 'content', content)),
     onCreateSnapComment: data => {
       dispatch(createSnapComment(data));
     },
@@ -104,7 +104,7 @@ const withConnect = connect(
 );
 
 const withReduxForm = reduxForm({
-  form: 'SnapCommentBar',
+  form: FORM_ID,
 });
 
 export default compose(

--- a/src/redux/snapComment/actions.js
+++ b/src/redux/snapComment/actions.js
@@ -1,7 +1,10 @@
 import { API, graphqlOperation } from 'aws-amplify';
 import * as mutations from 'graphql/mutations';
+import actions from 'redux-form/es/actions';
 import get from 'lodash/get';
 import { message } from 'antd';
+
+import { FORM_ID as SNAP_COMMENT_FORM_ID } from 'containers/DispatchPage/SnapCommentBar';
 
 export function createSnapComment(data) {
   return async (dispatch, getState) => {
@@ -45,6 +48,8 @@ export function createSnapComment(data) {
         await API.graphql(
           graphqlOperation(mutations.createSnapComment, params),
         );
+        // Reset snap-comment form field
+        dispatch(actions.reset(SNAP_COMMENT_FORM_ID));
         message.success('Add comment succeeded');
       } catch (error) {
         console.log(error);


### PR DESCRIPTION
- Canned messages button with color
- Reset snap-comment after submit success
![image](https://user-images.githubusercontent.com/7557956/52627178-c80f0600-2eef-11e9-8935-5633002698ea.png)
