### PR TITLE
Fix the console bug when logging html element

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,7 @@ import Amplify from 'aws-amplify';
 import awsConfig from 'aws-exports';
 
 import 'antd/dist/antd.css';
-import initErrorLogging from 'utils/sentry';
+// import initErrorLogging from 'utils/sentry';
 
 import Route from './route';
 
@@ -15,7 +15,8 @@ import './asset/css/index.css';
 // set amplify default config
 Amplify.configure(awsConfig);
 
-initErrorLogging();
+// This function make a bug which freezes the program when console.log an element
+// initErrorLogging();
 
 // Create redux store
 const initialState = {};


### PR DESCRIPTION
In before version, logging any html element (such as event.target) will freeze the program.
It might cause by the sentry/browser package. Abandon the package have solved the problem.